### PR TITLE
fix: suppress terminal bell in context selection screen

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,7 @@ var rootCmd = &cobra.Command{
 			Label:     "Select a context",
 			Items:     contexts,
 			Templates: templates,
+			Stdout:    utils.NoBellStdout,
 		}
 
 		// Set current context as initial selection

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ryo-nabata/kubec
 go 1.24.4
 
 require (
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/fatih/color v1.18.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/cobra v1.9.1
@@ -10,7 +11,6 @@ require (
 )
 
 require (
-	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/utils/ui.go
+++ b/utils/ui.go
@@ -2,8 +2,32 @@ package utils
 
 import (
 	"fmt"
+	"io"
+
+	"github.com/chzyer/readline"
 	"github.com/fatih/color"
 )
+
+// noBellStdout wraps readline's stdout and discards bell characters (\a)
+// so that promptui.Select does not trigger the terminal beep on every
+// keystroke (see manifoldco/promptui#49).
+type noBellStdout struct {
+	w io.Writer
+}
+
+func (n *noBellStdout) Write(p []byte) (int, error) {
+	if len(p) == 1 && p[0] == readline.CharBell {
+		return len(p), nil
+	}
+	return n.w.Write(p)
+}
+
+func (n *noBellStdout) Close() error {
+	return nil
+}
+
+// NoBellStdout is passed to promptui.Select.Stdout to suppress terminal bells.
+var NoBellStdout io.WriteCloser = &noBellStdout{w: readline.Stdout}
 
 func PrintSuccess(message string) {
 	fmt.Printf("✓ %s\n", color.GreenString(message))

--- a/utils/ui_test.go
+++ b/utils/ui_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/chzyer/readline"
+)
+
+func TestNoBellStdoutSuppressesSingleBell(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := &noBellStdout{w: buf}
+
+	n, err := w.Write([]byte{readline.CharBell})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("n = %d, want 1", n)
+	}
+	if got := buf.String(); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestNoBellStdoutPassesThroughNormalOutput(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := &noBellStdout{w: buf}
+
+	input := "Select a context"
+	n, err := w.Write([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(input) {
+		t.Errorf("n = %d, want %d", n, len(input))
+	}
+	if got := buf.String(); got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestNoBellStdoutPassesThroughMultiByteWithBell(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := &noBellStdout{w: buf}
+
+	input := []byte{'a', readline.CharBell, 'b'}
+	n, err := w.Write(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(input) {
+		t.Errorf("n = %d, want %d", n, len(input))
+	}
+	if got := buf.Bytes(); !bytes.Equal(got, input) {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestNoBellStdoutCloseIsNoop(t *testing.T) {
+	w := &noBellStdout{w: &bytes.Buffer{}}
+	if err := w.Close(); err != nil {
+		t.Errorf("Close() = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## 概要

`kubec` のコンテキスト選択画面で、キー操作のたびに macOS のシステム Beep 音が鳴る問題を修正する。

## 原因

`promptui.Select` が内部で使う `chzyer/readline` が、リスト端での矢印キー操作などでベル文字（`\a` / 0x07）を stdout に出力するため（promptui の既知問題 manifoldco/promptui#49）。

## 変更内容

- `utils/ui.go`: ベル 1 バイトのみの書き込みを捨てて他はそのまま通す `NoBellStdout`（`io.WriteCloser`）を追加
  - `Write` は捨てる場合も `len(p), nil` を返し、短い書き込み（`io.ErrShortWrite`）扱いを回避
  - `Close` は no-op（`os.Stdout` を閉じない — promptui が内部で `rl.Close()` を呼ぶため）
- `cmd/root.go`: `promptui.Select` に `Stdout: utils.NoBellStdout` を設定
- `utils/ui_test.go`: ユニットテスト追加（ベル単体は捨てる / 通常出力は通す / ベルを含む複数バイト列は通す / Close はエラーなし）
- `go.mod`: `chzyer/readline` が indirect → direct 依存に昇格（新規依存は無し）

## 検証

- [x] `go build ./...` / `go vet ./...` / `go test ./...` すべて成功
- [ ] 実機で選択画面を操作して Beep が鳴らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)