### PR TITLE
feat: add "unset current context" option to interactive selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ kubec
 ```
 A list of available contexts will be displayed and you can select using arrow keys.
 
-The list starts with a special **`<未選択 / unset current-context>`** entry, which is the default cursor position. Selecting it clears the current context (equivalent to `kubectl config unset current-context`), leaving no context selected. The entry matching the active context is annotated with `(current)`.
+The cursor starts on the active context (annotated with `(current)`). The list also includes a special **`<unset current-context>`** entry at the top; selecting it clears the current context (equivalent to `kubectl config unset current-context`), leaving no context selected.
 
 ### Direct Specification
 ```bash
@@ -41,7 +41,7 @@ kubec -c
 Display the currently active context.
 
 ### Unset Context
-Run interactive mode and choose the `<未選択 / unset current-context>` entry (selected by default):
+Run interactive mode and choose the `<unset current-context>` entry:
 ```bash
 kubec
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ kubec
 ```
 A list of available contexts will be displayed and you can select using arrow keys.
 
+The list starts with a special **`<未選択 / unset current-context>`** entry, which is the default cursor position. Selecting it clears the current context (equivalent to `kubectl config unset current-context`), leaving no context selected. The entry matching the active context is annotated with `(current)`.
+
 ### Direct Specification
 ```bash
 kubec my-cluster
@@ -37,6 +39,13 @@ kubec --current
 kubec -c
 ```
 Display the currently active context.
+
+### Unset Context
+Run interactive mode and choose the `<未選択 / unset current-context>` entry (selected by default):
+```bash
+kubec
+```
+This removes the `current-context` key from your kubeconfig so that no context is selected. All other kubeconfig fields are preserved.
 
 ## Prerequisites
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,13 +69,19 @@ var rootCmd = &cobra.Command{
 		currentContext := utils.GetCurrentContext()
 
 		// Build selectable items: the "unset" entry first, then each context.
-		// The current context is flagged so it can be marked in the list.
+		// The cursor defaults to the current context for orientation (so an
+		// accidental Enter just re-selects the current context rather than
+		// unsetting it). Unsetting is always available as the first entry.
 		items := []contextItem{{Name: unsetContextLabel, IsUnset: true}}
+		cursorPos := 0
 		for _, context := range contexts {
 			items = append(items, contextItem{
 				Name:      context,
 				IsCurrent: context == currentContext,
 			})
+			if context == currentContext {
+				cursorPos = len(items) - 1
+			}
 		}
 
 		// Create prompt template. The current context is annotated with
@@ -92,7 +98,7 @@ var rootCmd = &cobra.Command{
 			Label:     "Select a context",
 			Items:     items,
 			Templates: templates,
-			CursorPos: 0,                  // Default to the "unset" entry (no context selected)
+			CursorPos: cursorPos,          // Default to the current context
 			Stdout:    utils.NoBellStdout, // Suppress the terminal bell on navigation
 		}
 
@@ -125,7 +131,7 @@ var rootCmd = &cobra.Command{
 // unsetContextLabel is the menu entry shown in interactive mode that clears
 // the current-context. The angle brackets keep it from colliding with a real
 // Kubernetes context name.
-const unsetContextLabel = "<未選択 / unset current-context>"
+const unsetContextLabel = "<unset current-context>"
 
 // contextItem is a single entry in the interactive context selector.
 type contextItem struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,45 +67,70 @@ var rootCmd = &cobra.Command{
 		}
 
 		currentContext := utils.GetCurrentContext()
-		
-		// Create prompt template
+
+		// Build selectable items: the "unset" entry first, then each context.
+		// The current context is flagged so it can be marked in the list.
+		items := []contextItem{{Name: unsetContextLabel, IsUnset: true}}
+		for _, context := range contexts {
+			items = append(items, contextItem{
+				Name:      context,
+				IsCurrent: context == currentContext,
+			})
+		}
+
+		// Create prompt template. The current context is annotated with
+		// "(current)" so it stays identifiable even though the cursor
+		// defaults to the "unset" entry at the top.
 		templates := &promptui.SelectTemplates{
-			Label:    "{{ . }}",
-			Active:   "→ {{ . | cyan }}",
-			Inactive: "  {{ . | white }}",
-			Selected: "✓ {{ . | green }}",
+			Label:    "{{ .Name }}",
+			Active:   "→ {{ .Name | cyan }}{{ if .IsCurrent }} (current){{ end }}",
+			Inactive: "  {{ .Name }}{{ if .IsCurrent }} (current){{ end }}",
+			Selected: "✓ {{ .Name | green }}",
 		}
 
 		prompt := promptui.Select{
 			Label:     "Select a context",
-			Items:     contexts,
+			Items:     items,
 			Templates: templates,
+			CursorPos: 0, // Default to the "unset" entry (no context selected)
 		}
 
-		// Set current context as initial selection
-		if currentContext != "" {
-			for i, context := range contexts {
-				if context == currentContext {
-					prompt.CursorPos = i
-					break
-				}
-			}
-		}
-
-		_, selectedContext, err := prompt.Run()
+		selectedIndex, _, err := prompt.Run()
 		if err != nil {
 			fmt.Printf("Selection cancelled: %v\n", err)
 			return
 		}
+		selected := items[selectedIndex]
+
+		// Unset the current context
+		if selected.IsUnset {
+			if err := utils.UnsetCurrentContext(); err != nil {
+				log.Fatalf("Failed to unset context: %v", err)
+			}
+			fmt.Println("Current context unset (no context selected)")
+			return
+		}
 
 		// Switch context
-		err = utils.SetCurrentContext(selectedContext)
+		err = utils.SetCurrentContext(selected.Name)
 		if err != nil {
 			log.Fatalf("Failed to switch context: %v", err)
 		}
 
-		fmt.Printf("Switched to context '%s'\n", color.GreenString(selectedContext))
+		fmt.Printf("Switched to context '%s'\n", color.GreenString(selected.Name))
 	},
+}
+
+// unsetContextLabel is the menu entry shown in interactive mode that clears
+// the current-context. The angle brackets keep it from colliding with a real
+// Kubernetes context name.
+const unsetContextLabel = "<未選択 / unset current-context>"
+
+// contextItem is a single entry in the interactive context selector.
+type contextItem struct {
+	Name      string
+	IsCurrent bool
+	IsUnset   bool
 }
 
 func shouldRunDirectContextSwitch(arg string) bool {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,7 @@ var rootCmd = &cobra.Command{
 			Label:     "Select a context",
 			Items:     contexts,
 			Templates: templates,
+			Stdout:    utils.NoBellStdout,
 		}
 
 		// Set current context as initial selection

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ryo-nabata/kubec
 go 1.24.4
 
 require (
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/fatih/color v1.18.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/cobra v1.9.1
@@ -10,7 +11,6 @@ require (
 )
 
 require (
-	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/utils/kubernetes.go
+++ b/utils/kubernetes.go
@@ -166,6 +166,53 @@ func SetCurrentContext(contextName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to write kubeconfig: %v", err)
 	}
-	
+
+	return nil
+}
+
+// UnsetCurrentContext removes the top-level current-context key from the
+// kubeconfig, leaving no context selected. Unlike SetCurrentContext, this
+// edits the file via yaml.Node so that all other fields are preserved
+// verbatim, including ones not modeled by the KubeConfig struct
+// (e.g. extensions, proxy-url, exec plugin extras).
+func UnsetCurrentContext() error {
+	configPath := GetKubeConfigPath()
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return fmt.Errorf("kubeconfig file not found: %s", configPath)
+	}
+
+	data, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read kubeconfig file: %v", err)
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return fmt.Errorf("failed to parse kubeconfig file: %v", err)
+	}
+
+	if len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+		return fmt.Errorf("invalid kubeconfig format")
+	}
+
+	// Remove the top-level "current-context" key/value pair if present.
+	m := root.Content[0]
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == "current-context" {
+			m.Content = append(m.Content[:i], m.Content[i+2:]...)
+			break
+		}
+	}
+
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return fmt.Errorf("failed to prepare kubeconfig write: %v", err)
+	}
+
+	if err := ioutil.WriteFile(configPath, out, 0644); err != nil {
+		return fmt.Errorf("failed to write kubeconfig: %v", err)
+	}
+
 	return nil
 }

--- a/utils/kubernetes_test.go
+++ b/utils/kubernetes_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"gopkg.in/yaml.v3"
 )
@@ -227,5 +228,82 @@ func TestSetCurrentContext(t *testing.T) {
 	err = SetCurrentContext("non-existent-context")
 	if err == nil {
 		t.Error("Expected error when setting non-existent context, but got none")
+	}
+}
+
+func TestUnsetCurrentContext(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config")
+
+	// Raw kubeconfig including fields NOT modeled by the KubeConfig struct
+	// (top-level "extensions", cluster "proxy-url"/"tls-server-name") to
+	// verify they survive the unset operation.
+	rawConfig := `apiVersion: v1
+kind: Config
+current-context: context-a
+extensions:
+- name: custom-extension
+  extension:
+    foo: bar
+clusters:
+- name: cluster-a
+  cluster:
+    server: https://server-a
+    proxy-url: http://proxy.example.com:8080
+    tls-server-name: custom.tls.name
+contexts:
+- name: context-a
+  context:
+    cluster: cluster-a
+    user: user-a
+users:
+- name: user-a
+  user:
+    token: secret-token
+`
+
+	if err := os.WriteFile(configPath, []byte(rawConfig), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	os.Setenv("KUBECONFIG", configPath)
+	defer os.Unsetenv("KUBECONFIG")
+
+	if err := UnsetCurrentContext(); err != nil {
+		t.Fatalf("UnsetCurrentContext failed: %v", err)
+	}
+
+	// current-context should now be empty.
+	if got := GetCurrentContext(); got != "" {
+		t.Errorf("Expected empty current context after unset, but got '%s'", got)
+	}
+
+	// The current-context key itself should be removed from the file.
+	out, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read config after unset: %v", err)
+	}
+	written := string(out)
+	if strings.Contains(written, "current-context:") {
+		t.Errorf("Expected current-context key to be removed, but file still contains it:\n%s", written)
+	}
+
+	// Fields not modeled by the struct must be preserved verbatim.
+	preserved := []string{
+		"custom-extension",
+		"proxy-url: http://proxy.example.com:8080",
+		"tls-server-name: custom.tls.name",
+		"token: secret-token",
+	}
+	for _, want := range preserved {
+		if !strings.Contains(written, want) {
+			t.Errorf("Expected unset to preserve %q, but it was lost:\n%s", want, written)
+		}
+	}
+
+	// Contexts/clusters/users should still be intact and loadable.
+	contexts := GetContexts()
+	if len(contexts) != 1 || contexts[0] != "context-a" {
+		t.Errorf("Expected contexts to be preserved as [context-a], but got %v", contexts)
 	}
 }

--- a/utils/ui.go
+++ b/utils/ui.go
@@ -2,8 +2,32 @@ package utils
 
 import (
 	"fmt"
+	"io"
+
+	"github.com/chzyer/readline"
 	"github.com/fatih/color"
 )
+
+// noBellStdout wraps readline's stdout and discards bell characters (\a)
+// so that promptui.Select does not trigger the terminal beep on every
+// keystroke (see manifoldco/promptui#49).
+type noBellStdout struct {
+	w io.Writer
+}
+
+func (n *noBellStdout) Write(p []byte) (int, error) {
+	if len(p) == 1 && p[0] == readline.CharBell {
+		return len(p), nil
+	}
+	return n.w.Write(p)
+}
+
+func (n *noBellStdout) Close() error {
+	return nil
+}
+
+// NoBellStdout is passed to promptui.Select.Stdout to suppress terminal bells.
+var NoBellStdout io.WriteCloser = &noBellStdout{w: readline.Stdout}
 
 func PrintSuccess(message string) {
 	fmt.Printf("✓ %s\n", color.GreenString(message))

--- a/utils/ui_test.go
+++ b/utils/ui_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/chzyer/readline"
+)
+
+func TestNoBellStdoutSuppressesSingleBell(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := &noBellStdout{w: buf}
+
+	n, err := w.Write([]byte{readline.CharBell})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("n = %d, want 1", n)
+	}
+	if got := buf.String(); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestNoBellStdoutPassesThroughNormalOutput(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := &noBellStdout{w: buf}
+
+	input := "Select a context"
+	n, err := w.Write([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(input) {
+		t.Errorf("n = %d, want %d", n, len(input))
+	}
+	if got := buf.String(); got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestNoBellStdoutPassesThroughMultiByteWithBell(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := &noBellStdout{w: buf}
+
+	input := []byte{'a', readline.CharBell, 'b'}
+	n, err := w.Write(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(input) {
+		t.Errorf("n = %d, want %d", n, len(input))
+	}
+	if got := buf.Bytes(); !bytes.Equal(got, input) {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestNoBellStdoutCloseIsNoop(t *testing.T) {
+	w := &noBellStdout{w: &bytes.Buffer{}}
+	if err := w.Close(); err != nil {
+		t.Errorf("Close() = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## 概要

kubec から current-context を**未選択（解除）**にできるようにします。`kubectl config unset current-context` 相当の操作を、インタラクティブセレクターから行えます。意図しないクラスターを誤操作する事故を防ぐのが目的です。

## 変更点

- **`utils/kubernetes.go`**: `UnsetCurrentContext()` を追加。`yaml.Node` でトップレベルの `current-context` キーのみを削除し、それ以外のフィールドはそのまま保持します。struct にモデル化されていないフィールド（`extensions` / `proxy-url` / exec plugin の追加項目など）も失われません。
- **`cmd/root.go`**: インタラクティブセレクターの先頭に `<未選択 / unset current-context>` 項目を追加し、**デフォルトのカーソル位置**にしました。選択すると current-context を解除します。選択肢を構造体化し、現在のコンテキストには `(current)` マークを表示します。
- **`utils/kubernetes_test.go`**: `TestUnsetCurrentContext` を追加。キー削除と、struct 未定義フィールドの保持を検証します。
- **`README.md`**: 未選択項目の説明と「Unset Context」セクションを追記。

## 動作確認

- `go build ./...` / `go vet ./...` / `go test ./...` … すべて pass
- 手動（一時 KUBECONFIG、pty）:
  - 起動時カーソルが先頭の「未選択」（デフォルト未選択）
  - 現在のコンテキストに `(current)` 表示
  - 未選択を選択 → `Current context unset (no context selected)`、`current-context` キー削除、`proxy-url`/`token` 等は保持
  - `kubec --current` → `No current context is set`
  - 直接切替 `kubec <name>` は従来通り

## 補足

- `--unset` フラグは追加していません（unset の入口はインタラクティブの「未選択」項目に一本化）。
- 既存の `SetCurrentContext`（struct marshal 方式）は本 PR では変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)